### PR TITLE
add: noreferrer to <a rel>

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,2 +1,2 @@
 {{ $params := partial "params-helper.html" . }}
-<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if $params.openInNewTab }} target="_blank" rel="noopener"{{ end }}>{{ .Text | safeHTML }}</a> 
+<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if $params.openInNewTab }} target="_blank" rel="noopener noreferrer"{{ end }}>{{ .Text | safeHTML }}</a> 


### PR DESCRIPTION
Add rel="noreferrer" alongside rel="noopener" for links best practice, improving security and privacy of outgoing links. 