### PR TITLE
fix: c6ee95a commit had newline eof which added a space after links

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,2 +1,3 @@
 {{ $params := partial "params-helper.html" . }}
-<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if $params.openInNewTab }} target="_blank" rel="noopener noreferrer"{{ end }}>{{ .Text | safeHTML }}</a> 
+<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if $params.openInNewTab }} target="_blank" rel="noopener noreferrer"{{ end }}>{{ .Text | safeHTML }}</a>
+{{- /* Trim EOF */ -}}


### PR DESCRIPTION
Previous change (adding "noreferrer", commit:c6ee95a) resulted in empty space being added to end of links, for example:

`Example of this [link](https://link.com), in a sentence.` would result in:

`Example of this link , in a sentence.` Note the space added after the word `link` and is more noticable with links before punctuation.

`{{- /* Trim EOF */ -}}` added this to remove any spaces and new lines at the end of the render-link.html.