### PR TITLE
fix: render-link sensitive to spaces and newlines

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,3 +1,1 @@
-{{ $params := partial "params-helper.html" . }}
-<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if $params.openInNewTab }} target="_blank" rel="noopener noreferrer"{{ end }}>{{ .Text | safeHTML }}</a>
-{{- /* Trim EOF */ -}}
+{{ $params := partial "params-helper.html" . }}<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if $params.openInNewTab }} target="_blank" rel="noopener noreferrer"{{ end }}>{{ .Text | safeHTML }}</a>{{- /* Trim EOF */ -}}


### PR DESCRIPTION
Links renders with a space **BEFORE** the link text due to the newline right before the start of "<a href...". Now it's all on one line. (Sorry, @Junyi-99! I double checked this time, it's not breaking anything now.)